### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-- 2.0.0
-- 2.1.5
+- 2.1
+- 2.2
+- 2.3.5
+- 2.4.2
 install:
 - wget http://ftp.gnu.org/gnu/bison/bison-3.0.2.tar.gz
 - tar xf bison-3.0.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.5
-- 2.4.2
 install:
 - wget http://ftp.gnu.org/gnu/bison/bison-3.0.2.tar.gz
 - tar xf bison-3.0.2.tar.gz

--- a/fluent-plugin-filter-jq.gemspec
+++ b/fluent-plugin-filter-jq.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'test-unit', '>= 3.2.0'
 end

--- a/fluent-plugin-filter-jq.gemspec
+++ b/fluent-plugin-filter-jq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fluentd', '>= 0.12'
+  spec.add_dependency 'fluentd', ['>= 0.14.0', '< 2']
   spec.add_dependency 'ruby-jq'
   spec.add_dependency 'multi_json'
 

--- a/lib/fluent/plugin/filter_jq.rb
+++ b/lib/fluent/plugin/filter_jq.rb
@@ -1,10 +1,11 @@
 require 'fluent_plugin_filter_jq/version'
+require 'fluent/plugin/filter'
 require 'multi_json'
 require 'jq'
 
-module Fluent
+module Fluent::Plugin
   class JqFilter < Filter
-    Plugin.register_filter('jq', self)
+    Fluent::Plugin.register_filter('jq', self)
 
     config_param :jq, :string
     config_param :no_hash_root_key, :string, :default => '.'

--- a/spec/filter_jq_config_spec.rb
+++ b/spec/filter_jq_config_spec.rb
@@ -1,4 +1,4 @@
-describe 'Fluent::JqFilter#configure' do
+describe 'Fluent::Plugin::JqFilter#configure' do
   subject do |example|
     param = example.full_description.split(/\s+/)[1]
     create_driver(fluentd_conf).instance.send(param)
@@ -17,8 +17,8 @@ describe 'Fluent::JqFilter#configure' do
   end
 
   describe 'jq' do
-    context '{new_foo:.foo}' do
-      it { is_expected.to eq '{new_foo:.foo}' }
+    context '{new_foo: .foo}' do
+      it { is_expected.to eq "{new_foo: .foo}" }
     end
   end
 

--- a/spec/filter_jq_spec.rb
+++ b/spec/filter_jq_spec.rb
@@ -1,6 +1,8 @@
 
-describe Fluent::JqFilter do
-  let(:time) { Time.parse('2015/05/24 18:30 UTC').to_i }
+describe Fluent::Plugin::JqFilter do
+  include Fluent::Test::Helpers
+
+  let(:time) { event_time('2015/05/24 18:30 UTC') }
   let(:fluentd_conf) { {} }
 
   let(:driver) do |example|
@@ -16,20 +18,20 @@ describe Fluent::JqFilter do
   end
 
   before do
-    records.each do |record|
-      driver.emit(record, time)
+    driver.run(default_tag: 'test.default') do
+      records.each do |record|
+        driver.feed(time, record)
+      end
     end
-
-    driver.run
   end
 
-  subject { driver.emits }
+  subject { driver.filtered }
 
   context '.' do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo"=>"bar", "zoo"=>"baz"}],
-        ["test.default", time, {"foo"=>"zoo", "bar"=>"baz"}]
+        [time, {"foo"=>"bar", "zoo"=>"baz"}],
+        [time, {"foo"=>"zoo", "bar"=>"baz"}]
       ]
     end
   end
@@ -37,8 +39,8 @@ describe Fluent::JqFilter do
   context '{new_foo:.foo}' do
     it do
       is_expected.to eq [
-        ["test.default", time, {"new_foo"=>"bar"}],
-        ["test.default", time, {"new_foo"=>"zoo"}]
+        [time, {"new_foo"=>"bar"}],
+        [time, {"new_foo"=>"zoo"}]
       ]
     end
   end
@@ -46,10 +48,10 @@ describe Fluent::JqFilter do
   context '.[]' do
     it do
       is_expected.to match_array [
-        ["test.default", time, {"."=>"baz"}],
-        ["test.default", time, {"."=>"bar"}],
-        ["test.default", time, {"."=>"baz"}],
-        ["test.default", time, {"."=>"zoo"}]
+        [time, {"."=>"baz"}],
+        [time, {"."=>"bar"}],
+        [time, {"."=>"baz"}],
+        [time, {"."=>"zoo"}]
       ]
     end
   end
@@ -59,10 +61,10 @@ describe Fluent::JqFilter do
 
     it do
       is_expected.to match_array [
-        ["test.default", time, {"root"=>"baz"}],
-        ["test.default", time, {"root"=>"bar"}],
-        ["test.default", time, {"root"=>"baz"}],
-        ["test.default", time, {"root"=>"zoo"}]
+        [time, {"root"=>"baz"}],
+        [time, {"root"=>"bar"}],
+        [time, {"root"=>"baz"}],
+        [time, {"root"=>"zoo"}]
       ]
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_jq'
 require 'time'
 
@@ -16,7 +18,7 @@ end
 def create_driver(options = {})
   fluentd_conf = <<-EOS
 type object_flatten
-jq #{options.fetch(:jq)}
+jq "#{options.fetch(:jq)}"
   EOS
 
   if options[:no_hash_root_key]
@@ -25,6 +27,5 @@ no_hash_root_key #{options[:no_hash_root_key]}
     EOS
   end
 
-  tag = options[:tag] || 'test.default'
-  Fluent::Test::FilterTestDriver.new(Fluent::JqFilter, tag).configure(fluentd_conf)
+  Fluent::Test::Driver::Filter.new(Fluent::Plugin::JqFilter).configure(fluentd_conf)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,6 @@ no_hash_root_key #{options[:no_hash_root_key]}
 
   Fluent::Test::Driver::Filter.new(Fluent::Plugin::JqFilter).configure(fluentd_conf)
 end
+
+# prevent Test::Unit's AutoRunner from executing during RSpec's rake task
+Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.